### PR TITLE
Loafedit

### DIFF
--- a/src/framework.md
+++ b/src/framework.md
@@ -1,3 +1,9 @@
 # Framework
 
 This chapter presents the features of the Dojo core programming framework. This covers the ECS (Entity Component System), Commands, and Extensibility.
+
+### World
+
+### Components
+
+### Systems

--- a/src/framework.md
+++ b/src/framework.md
@@ -1,9 +1,3 @@
 # Framework
 
 This chapter presents the features of the Dojo core programming framework. This covers the ECS (Entity Component System), Commands, and Extensibility.
-
-### World
-
-### Components
-
-### Systems

--- a/src/framework/commands.md
+++ b/src/framework/commands.md
@@ -1,1 +1,23 @@
 # Commands
+
+Commands in Dojo are generalized functions that are expanded at compile time to facilitate system execution. They provide a convenient way for systems to interact with the world state by abstracting common operations, such as retrieving or updating components, and generating unique IDs. By leveraging these commands, developers can streamline their system implementations and improve code readability.
+
+Understanding commands is key to understanding Dojo. You will leverage them heavily within the systems you design.
+
+```rust
+// Retrieve a unique ID from the world, which is helpful when creating a new entity.
+// This function returns a globally unique identifier that can be used as an entity ID.
+fn commands::uuid() -> felt252;
+
+// Update an existing entity by setting its components with the provided values.
+// This function takes a storage key representing the entity and a generic type T for the components to be updated.
+fn commands::set(storage_key: StorageKey, components: T);
+
+// Retrieve the components of a specific type T for an entity identified by the storage key.
+// This function returns the components as an instance of the generic type T.
+fn commands::<T>::get(storage_key: StorageKey) -> T;
+
+// Retrieve all entity IDs that have components matching the provided type T.
+// This function returns an array of entity IDs (felt252) containing the specified components.
+fn commands::<T>::entities() -> Array<felt252>;
+```

--- a/src/framework/components.md
+++ b/src/framework/components.md
@@ -1,1 +1,25 @@
 # Components
+
+Components serve as the foundation for defining the world's structure, encapsulating state for systems to mutate. For instance, a Position component can be implemented as a struct, exposing `is_zero` and `is_equal` methods. Dojo compiles these components into contracts that can be declared and installed within a world, enabling the creation of diverse and customizable environments.
+
+When designing a world's components, it is crucial to carefully consider the abstractions you create, always keeping composability in mind.
+
+Suppose you plan to create two entities that move around the map and are fundamentally different from each other, except for the fact that they both exist within the world. In this case, you could create a shared Position component for both entities. This demonstrates the power of the Entity Component System (ECS) abstraction: by writing a single component, you can reuse it across multiple diverse entities, promoting modularity and flexibility within your world design.
+
+```rust
+#[derive(Component)]
+struct Position {
+    x: u32,
+    y: u32
+}
+
+trait PositionTrait {
+    fn is_equal(self: Position, b: Position) -> bool;
+}
+
+impl PositionImpl of PositionTrait {
+    fn is_equal(self: Position, b: Position) -> bool {
+        self.x == b.x & self.y == b.y
+    }
+}
+```

--- a/src/framework/entities.md
+++ b/src/framework/entities.md
@@ -1,1 +1,57 @@
 # Entities
+
+A common misconception for those new to ECS systems is the way entities exist within the World. Different ECS systems handle entities in various ways. In Dojo, entities are treated as a primary key value within the world, to which components can be attached. To illustrate this concept, consider a simple example of a character in a game that has a position and a health component.
+
+When defining the components for this entity, it is important to note that we do not reference the entity directly. Instead, we simply provide two structs that the entity will contain. This approach emphasizes the flexibility and composability of the ECS system, allowing for the easy creation and modification of entities with various combinations of components.
+
+```rust
+#[derive(Component)]
+struct Position {
+    x: u32,
+    y: u32
+}
+
+#[derive(Component)]
+struct Health {
+    value: u32,
+}
+
+```
+
+Now, let's create a `SpawnSystem` for the character. It is important to note that we have not explicitly defined an Entity anywhere. Instead, the system will assign a primary key ID to the entity when this system is executed. 
+
+```rust
+// The most basic system that creates a new player entity with a given name and 100 health.
+
+#[system]
+mod SpawnSystem {
+    // The execute function takes a name as input and creates a new player entity with the specified name and 100 health.
+    fn execute(name: String) {
+        // Using a command generate a new player ID and create the player entity with the Health and Name components.
+        let player_id = commands::create((
+            Health::new(100_u8),
+            Name::new(name),
+        ));
+        // The system has no return value.
+        return ();
+    }
+}
+```
+
+Finally, lets move the character with the `MoveSystem`.
+
+```rust
+#[system]
+mod MoveSystem {
+    fn execute(player_id: usize) {
+        let player = commands<(Health, Name)>::get(player_id);
+        let positions = commands<(Position, Health)>::entities();
+
+        // @NOTE: Loops are not available in Cairo 1.0 yet.
+        for (position, health) in positions {
+            let is_zero = position.is_zero();
+        }
+        return ();
+    }
+}
+```

--- a/src/framework/overview.md
+++ b/src/framework/overview.md
@@ -1,3 +1,3 @@
 # Overview
 
-The Dojo framework, represents worlds using an Entity Component System (ECS). The ECS provides a simple, modular archtecture for reasoning about a worlds state and state transition functions.
+Dojo employs an Entity Component System (ECS) to represent worlds. The ECS offers a straightforward and modular architecture for understanding a world's state and its state transition functions. By separating concerns into distinct entities, components, and systems, the ECS approach enables developers to easily manage complex interactions, create reusable code, and promote maintainability in their projects.

--- a/src/framework/systems.md
+++ b/src/framework/systems.md
@@ -1,1 +1,47 @@
 # Systems
+
+Systems represent functions that operate on the world state. They take input from the user, retrieve the current state from the world, compute a state transition, and apply it. Each system has a single entry point, the execute function. To streamline interaction with the world, systems can utilize 
+commands.
+
+```rust
+// The most basic system that creates a new player entity with a given name and 100 health.
+
+#[system]
+mod SpawnSystem {
+    // The execute function takes a name as input and creates a new player entity with the specified name and 100 health.
+    fn execute(name: String) {
+        // Using a command generate a new player ID and create the player entity with the Health and Name components.
+        let player_id = commands::create((
+            Health::new(100_u8),
+            Name::new(name),
+        ));
+        // The system has no return value.
+        return ();
+    }
+}
+```
+
+
+### Commands
+
+Commands in Dojo are generalized functions that are expanded at compile time to facilitate system execution. They provide a convenient way for systems to interact with the world state by abstracting common operations, such as retrieving or updating components, and generating unique IDs. By leveraging these commands, developers can streamline their system implementations and improve code readability.
+
+Understanding commands is key to understanding Dojo. You will leverage them heavily within the systems you design.
+
+```rust
+// Retrieve a unique ID from the world, which is helpful when creating a new entity.
+// This function returns a globally unique identifier that can be used as an entity ID.
+fn commands::uuid() -> felt252;
+
+// Update an existing entity by setting its components with the provided values.
+// This function takes a storage key representing the entity and a generic type T for the components to be updated.
+fn commands::set(storage_key: StorageKey, components: T);
+
+// Retrieve the components of a specific type T for an entity identified by the storage key.
+// This function returns the components as an instance of the generic type T.
+fn commands::<T>::get(storage_key: StorageKey) -> T;
+
+// Retrieve all entity IDs that have components matching the provided type T.
+// This function returns an array of entity IDs (felt252) containing the specified components.
+fn commands::<T>::entities() -> Array<felt252>;
+```

--- a/src/framework/systems.md
+++ b/src/framework/systems.md
@@ -21,27 +21,3 @@ mod SpawnSystem {
 }
 ```
 
-
-### Commands
-
-Commands in Dojo are generalized functions that are expanded at compile time to facilitate system execution. They provide a convenient way for systems to interact with the world state by abstracting common operations, such as retrieving or updating components, and generating unique IDs. By leveraging these commands, developers can streamline their system implementations and improve code readability.
-
-Understanding commands is key to understanding Dojo. You will leverage them heavily within the systems you design.
-
-```rust
-// Retrieve a unique ID from the world, which is helpful when creating a new entity.
-// This function returns a globally unique identifier that can be used as an entity ID.
-fn commands::uuid() -> felt252;
-
-// Update an existing entity by setting its components with the provided values.
-// This function takes a storage key representing the entity and a generic type T for the components to be updated.
-fn commands::set(storage_key: StorageKey, components: T);
-
-// Retrieve the components of a specific type T for an entity identified by the storage key.
-// This function returns the components as an instance of the generic type T.
-fn commands::<T>::get(storage_key: StorageKey) -> T;
-
-// Retrieve all entity IDs that have components matching the provided type T.
-// This function returns an array of entity IDs (felt252) containing the specified components.
-fn commands::<T>::entities() -> Array<felt252>;
-```

--- a/src/framework/world.md
+++ b/src/framework/world.md
@@ -1,20 +1,22 @@
 # World
 
-The world acts like a kernel. Contracts are deployed, registered and executed via it. This allows systems upstream to interact with a single contract and not hundreds.
-
-The world interface is as follows:
+The world functions as a central system kernel, serving as the foundation for initiating and resolving all interactions. Within this kernel, contracts are deployed, registered, and executed, streamlining the process for downstream systems by enabling them to engage with a single contract rather than managing hundreds.
 
 ```rust
 trait World {
+    // Event emitted when a record is set in the store.
     #[event]
     fn StoreSetRecord(table_id: felt252, key: Span<felt252>, value: Span<felt252>) {}
 
+    // Event emitted when a field is set in the store.
     #[event]
     fn StoreSetField(table_id: felt252, key: Span<felt252>, offset: u8, value: Span<felt252>) {}
 
+    // Event emitted when a component is registered.
     #[event]
     fn ComponentRegistered(name: felt252, class_hash: ClassHash) {}
 
+    // Event emitted when a system is registered.
     #[event]
     fn SystemRegistered(name: felt252, class_hash: ClassHash) {}
 
@@ -34,11 +36,11 @@ trait World {
     #[external]
     fn set(component: felt252, key: StorageKey, offset: u8, value: Span<felt252>);
 
-    // Returns all entities that contain the component.
+    // Registers a new component.
     #[external]
     fn register_component(name: felt252, class_hash: ClassHash);
 
-    // Returns all entities that contain the component.
+    // Registers a new system.
     #[external]
     fn register_system(name: felt252, class_hash: ClassHash);
 }

--- a/src/framework/world.md
+++ b/src/framework/world.md
@@ -1,5 +1,7 @@
 # World
 
+The world acts like a kernel. Contracts are deployed, registered and executed via it. This allows systems upstream to interact with a single contract and not hundreds.
+
 The world interface is as follows:
 
 ```rust

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -1,3 +1,5 @@
 # Getting started
 
-TODO
+Clone starter project
+
+Build, deploy and interact.

--- a/src/getting-started.md
+++ b/src/getting-started.md
@@ -2,4 +2,4 @@
 
 Clone starter project
 
-Build, deploy and interact.
+`git clone https://github.com/dojoengine/dojo-starter.git`

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -6,6 +6,11 @@ Dojo leverages an [entity component system](https://en.wikipedia.org/wiki/Entity
 
 ## Autonomous Worlds
 
+Autonomous worlds bear a remarkable resemblance to blockchains in their nature. Once established, they endure, with their state persisting for the duration of the chain. Players can join or leave, and developers can build upon these worlds by deploying features in a permissionless way, akin to how contracts are deployed onto a chain. There is no universally accepted definition for an Autonomous World; however, our criteria for labeling a game as such requires at least these two essential features:
+
+1. Decentralized data availability layer: While the state execution may reside on a centralized layer, it is crucial that the state can be reconstructed if the execution layer ceases to exist. Rollups offer a solution, providing increased capacity execution layers while ensuring data is permanently settled on Ethereum. This guarantees the world's perpetual persistence.
+
+2. Permissionless entry point for expanding the world: The World contract must be capable of accepting new systems and components without requiring permission. While this doesn't imply that every component and system will be utilized, they must adhere to this pattern, ensuring open and unrestricted access for potential enhancements.
 
 
 ## Motivation

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -6,20 +6,27 @@ Dojo leverages an [entity component system](https://en.wikipedia.org/wiki/Entity
 
 ## Autonomous Worlds
 
-Autonomous worlds bear a remarkable resemblance to blockchains in their nature. Once established, they endure, with their state persisting for the duration of the chain. Players can join or leave, and developers can build upon these worlds by deploying features in a permissionless way, akin to how contracts are deployed onto a chain. There is no universally accepted definition for an Autonomous World; however, our criteria for labeling a game as such requires at least these two essential features:
+> Autonomous worlds represent persistent, permissionless, and decentralized open environments that users can freely interact with and contribute to. - anon
+
+The precise definition of Autonomous Worlds (AWs) remains somewhat elusive, as it is more of an abstract concept that has yet to be fully crystallized. Lattice Labs first introduced the terminology in 2022, but the notion of open worlds operating on the blockchain has been around for a while. The abstraction introduced by MUD served as a catalyst for the market to recognize the potential of these worlds.
+
+Autonomous Worlds share notable similarities with blockchains in their fundamental nature. Once established, they persist, maintaining their state throughout the lifespan of the chain. Players can join or leave, and developers can expand these worlds by deploying features in a permissionless manner, much like how contracts are added to a chain. While there is no universally accepted definition for an Autonomous World, we believe that a game must possess at least the following two essential features to be considered as such:
 
 1. Decentralized data availability layer: While the state execution may reside on a centralized layer, it is crucial that the state can be reconstructed if the execution layer ceases to exist. Rollups offer a solution, providing increased capacity execution layers while ensuring data is permanently settled on Ethereum. This guarantees the world's perpetual persistence.
 
 2. Permissionless entry point for expanding the world: The World contract must be capable of accepting new systems and components without requiring permission. While this doesn't imply that every component and system will be utilized, they must adhere to this pattern, ensuring open and unrestricted access for potential enhancements.
 
-
-## Motivation
-
 ### ECS
 
 ### Cairo lang
 
+The Cairo VM and its differences from the EVM.
+Custom compiler
 
 ### Dojo Aspirations
 
+The 0-1 moment. 
+
 ### Organisational Structure
+
+Dojo is an open-source, MIT-licensed project dedicated to advancing the concept of Autonomous Worlds (AWs).

--- a/src/introduction.md
+++ b/src/introduction.md
@@ -3,3 +3,18 @@
 Dojo is an engine for building Autonomous Worlds. It is designed to simplify the process of creating, managing, and scaling these ever expanding onchain universes.
 
 Dojo leverages an [entity component system](https://en.wikipedia.org/wiki/Entity_component_system) and [diamond](https://eips.ethereum.org/EIPS/eip-2535) pattern to provide a modular, extensible world. Worlds are expanded through the introduction of Components (state) and Systems (logic).
+
+## Autonomous Worlds
+
+
+
+## Motivation
+
+### ECS
+
+### Cairo lang
+
+
+### Dojo Aspirations
+
+### Organisational Structure


### PR DESCRIPTION
added prelim sections

when talking about Dojo, try to just use `Dojo is` rather than `Dojo framework is` or `Dojo engine is` etc.