### PR TITLE
Update internal links

### DIFF
--- a/src/framework/katana/overview.md
+++ b/src/framework/katana/overview.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-`katana` binary is available via [`dojoup`](../../getting-started/installation.md).
+`katana` binary is available via [`dojoup`](../../getting-started/installation.md#using-dojoup).
 
 ### Installing from source
 

--- a/src/framework/sozo/overview.md
+++ b/src/framework/sozo/overview.md
@@ -8,7 +8,7 @@
 
 ## Installation
 
-The `sozo` binary can be installed via [`dojoup`](../../getting-started/installation.md), our dedicated installation package manager.
+The `sozo` binary can be installed via [`dojoup`](../../getting-started/installation.md#using-dojoup), our dedicated installation package manager.
 
 ### Installing from Source
 

--- a/src/theory/cairo.md
+++ b/src/theory/cairo.md
@@ -4,7 +4,7 @@ Cairo is an open-source, Turing-complete smart contract language developed by St
 
 Dojo builds on Cairo to create a robust framework for developing Autonomous Worlds (AWs). By leveraging the capabilities of Cairo, Dojo aims to streamline the development process, improve maintainability, and enhance the performance of AWs.
 
-A key feature of the Dojo framework is its use of [commands](./framework/commands.md). Commands are a design pattern that helps to reduce boilerplate code, resulting in cleaner and more maintainable applications. They achieve this by encapsulating specific actions or operations within self-contained, reusable units.
+A key feature of the Dojo framework is its use of [commands](../framework/cairo/commands.md). Commands are a design pattern that helps to reduce boilerplate code, resulting in cleaner and more maintainable applications. They achieve this by encapsulating specific actions or operations within self-contained, reusable units.
 
 Developers can write commands freely within Systems, and the Cairo compiler takes care of inlining the appropriate functions. 
 


### PR DESCRIPTION
This PR provide the following modifications:
- fix broken link to 'commands' in theory/cairo
- add missing #using-dojoup for reference to dojoup
