### PR TITLE
fix: typos

### DIFF
--- a/src/cairo/commands.md
+++ b/src/cairo/commands.md
@@ -51,10 +51,10 @@ Here we are updating the `Moves` and `Position` models in the world state using 
 
 ### The `emit!` command
 
-The `emit!` command is used to emit custom events. These events are indexed by [torii](../toolchain/torii/overview.md)
+The `emit!` command is used to emit custom events. These events are indexed by [Torii](../toolchain/torii/overview.md).
 
 ```rust,ignore
 emit!(world, Moved { address: caller, direction });
 ```
 
-This will emit these values which could be captured by a client or you could query these via [torii](../toolchain/torii/overview.md)
+This will emit these values which could be captured by a client or you could query these via [Torii](../toolchain/torii/overview.md).

--- a/src/cairo/config.md
+++ b/src/cairo/config.md
@@ -1,8 +1,8 @@
 # Config
 
-Dojo worlds are defined in their Scarb.toml files. This is just a regular [Scarb](https://docs.swmansion.com/scarb/) file which is an excellent Cairo package manager and project manager.
+Dojo worlds are defined in their `Scarb.toml` files. This is just a regular [Scarb](https://docs.swmansion.com/scarb/) file which is an excellent Cairo package manager and project manager.
 
-Full example of a Scarb.toml file:
+Full example of a `Scarb.toml` file:
 
 ```toml
 [package]

--- a/src/cairo/events.md
+++ b/src/cairo/events.md
@@ -72,7 +72,7 @@ These events are also captured by [Torii](../toolchain/torii/overview.md) and in
 
 ### Custom Events
 
-Within your systems, emitting custom events can be highly beneficial. Fortunately, there's a handy `emit!` macro that lets you release events directly from your world. These events are indexed by [torii](../toolchain/torii/overview.md)
+Within your systems, emitting custom events can be highly beneficial. Fortunately, there's a handy `emit!` command that lets you release events directly from your world. These events are indexed by [Torii](../toolchain/torii/overview.md).
 
 Use it like so:
 
@@ -105,4 +105,4 @@ fn move(ctx: Context, direction: Direction) {
 }
 ```
 
-> Note: Read about the `get!` and `set!` macros in [Commands](./commands.md).
+> Note: Read about the `get!` and `set!` commands in the [Commands](./commands.md) chapter.

--- a/src/cairo/hello-dojo.md
+++ b/src/cairo/hello-dojo.md
@@ -258,11 +258,11 @@ actions
 
 ```
 
-Your 🌎 is now deployed at `0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973`!
+Your 🌎 is now deployed at `0x5010c31f127114c6198df8a5239e2b7a5151e1156fb43791e37e7385faa8138`!
 
 This establishes the world address for your project.
 
-Let's discuss the `Scarb.toml` file in the project. This file contains environment variables that make running CLI commands in your project a breeze. (Read more about it [here](./config.md)). Make sure your file specifies the version of Dojo you have installed!. In this case version `0.3.10`
+Let's discuss the `Scarb.toml` file in the project. This file contains environment variables that make running CLI commands in your project a breeze (read more about it [here](./config.md)). Make sure your file specifies the version of Dojo you have installed! In this case version `0.3.13`.
 
 ```toml
 [dependencies]
@@ -274,10 +274,10 @@ dojo = { git = "https://github.com/dojoengine/dojo", version = "0.3.13" }
 With your local world address established, let's delve into indexing. You can index the entire world. To accomplish this we have to copy your world address from the output of `sozo migrate`. Now Open a new terminal and input this simple command that includes your own world address:
 
 ```bash
-torii --world 0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973
+torii --world 0x5010c31f127114c6198df8a5239e2b7a5151e1156fb43791e37e7385faa8138
 ```
 
-Running the command mentioned above starts a Torii server on your local machine. This server uses SQLite as its database and is accessible at http://0.0.0.0:8080/graphql. Torii will automatically organize your data into tables, making it easy for you to perform queries using GraphQL. When you run the command, you'll see terminal output that looks something like this:
+Running the command mentioned above starts a [Torii](../toolchain/torii/overview.md) server on your local machine. This server uses SQLite as its database and is accessible at http://0.0.0.0:8080/graphql. [Torii](../toolchain/torii/overview.md) will automatically organize your data into tables, making it easy for you to perform queries using GraphQL. When you run the command, you'll see terminal output that looks something like this:
 
 ```bash
 2023-10-18T06:49:48.184233Z  INFO torii::server: 🚀 Torii listening at http://0.0.0.0:8080

--- a/src/cairo/models.md
+++ b/src/cairo/models.md
@@ -212,7 +212,7 @@ mod spawnHuman {
     use dojo_examples::models::Potions;
     use dojo_examples::models::Counter;
 
-    // we can set the counter value as a const, then query it easily! This pattern is useful for settins.
+    // we can set the counter value as a const, then query it easily! This pattern is useful for settings.
     const COUNTER_ID: u32 = 9999999999999;
 
     // impl: implement functions specified in trait

--- a/src/cairo/testing.md
+++ b/src/cairo/testing.md
@@ -13,7 +13,7 @@ This will search for all tests within your project and run them.
 
 ### Writing Unit Tests
 
-It is best practise to include unit tests in the same file as the model/System you are writing.
+It is best practise to include unit tests in the same file as the Model/System you are writing.
 
 Lets show a `model` test example from the [dojo-starter](https://github.com/dojoengine/dojo-starter):
 


### PR DESCRIPTION
Fix some typos.

@ponderingdemocritus I've run prettier but there is a lot's of diff. Are you using a special script/tool for this?
We may include it (or something similar) and make a check in the CI. This could help to keep the markdown formatted, WDYT?