### PR TITLE
chore: git clone link updated

### DIFF
--- a/src/client/sdk/unity.md
+++ b/src/client/sdk/unity.md
@@ -13,7 +13,7 @@ Ensure that you're using the latest supported Dojo [version](https://github.com/
 If you are using Windows or Linux, you will need to build [dojo.c](https://github.com/dojoengine/dojo.c) yourself. Make sure that you're using the latest supported version
 
 ```bash
-git clone git@github.com:dojoengine/dojo.c.git
+git clone https://github.com/dojoengine/dojo.c
 cargo build --release
 ```
 


### PR DESCRIPTION
As git clone git@github.com:dojoengine/dojo.c.git
cargo build --release 

Returns Error the following error:  git clone git@github.com:dojoengine/dojo.c.git
fatal: could not create work tree dir 'dojo.c': Permission denied

C:\Users>cargo build --release
'cargo' is not recognized as an internal or external command, operable program or batch file.


Changing the code to git clone https://github.com/dojoengine/dojo works