### PR TITLE
Fix chess example hyperlink

### DIFF
--- a/src/tutorial/onchain-chess/0-setup.md
+++ b/src/tutorial/onchain-chess/0-setup.md
@@ -200,6 +200,6 @@ struct GameTurn {
 
 </details>
 
-This tutorial is extracted from [here](https://github.com/dojoengine/origami/tree/main/dojo-chess)
+This tutorial is extracted from [here](https://github.com/dojoengine/origami/tree/main/examples/chess)
 
 Congratulations! You've completed the basic setup for building an on-chain chess game 🎉


### PR DESCRIPTION
Fix Chess example hyperlink to origami repository. Currently its broken.