### PR TITLE
Remove load_state from the katana reference

### DIFF
--- a/src/toolchain/katana/reference.md
+++ b/src/toolchain/katana/reference.md
@@ -166,9 +166,6 @@ Set an exact value of a contract's storage slot.
 &nbsp;&nbsp;&nbsp;&nbsp; Dump the state of chain on exit to the given file.  
 &nbsp;&nbsp;&nbsp;&nbsp; If the value is a directory, the state will be written to `<PATH>/state.bin`.
 
-`--load-state <PATH>`  
-&nbsp;&nbsp;&nbsp;&nbsp; Initialize the chain from a previously saved state snapshot.
-
 `--rpc-url <URL>`  
 &nbsp;&nbsp;&nbsp;&nbsp; The Starknet RPC provider to fork the network from.
 


### PR DESCRIPTION
Since https://github.com/dojoengine/dojo/commit/431d015e3fc43a72f528fbeac741a098b667f7e7 load_state is not there anymore