### PR TITLE
chore: update unity.md

### DIFF
--- a/src/client/sdk/unity.md
+++ b/src/client/sdk/unity.md
@@ -100,4 +100,4 @@ Get started by:
 0. [Prerequisites](#prerequisites)
 1. Cloning the [dojo.unity](https://github.com/dojoengine/dojo.unity)
 2. Open project within Unity
-3. Run the [dojo-starter](https://book.dojoengine.org/cairo/hello-dojo.html) project and make sure to have Katana and Torii running.
+3. Run the [dojo-starter](https://github.com/dojoengine/dojo-starter-unity) project and make sure to have Katana and Torii running.


### PR DESCRIPTION
The link with the ahref (dojo-starter-unity) was pointing to https://book.dojoengine.org/cairo/hello-dojo.html instead of the [Dojo Starter Unity Page] (https://github.com/dojoengine/dojo-starter-unity)