### PR TITLE
Update section Sozo model

### DIFF
--- a/src/toolchain/sozo/world-commands/model.md
+++ b/src/toolchain/sozo/world-commands/model.md
@@ -17,6 +17,17 @@ Commands:
 
 ### SUBCOMMANDS
 
+**Note**: Before to execute the following subcommands, ensure you have added your `world address` to your Scarb.toml file.
+
+```toml
+[tool.dojo.env]
+rpc_url = "http://localhost:5050/"
+# Default account for katana with seed = 0
+account_address = "0x517ececd29116499f4a1b64b094da79ba08dfd54a3edaa316134c41f8160973"
+private_key = "0x1800000000300000180000000000030000000000003006001800006600"
+world_address = "0x28f5999ae62fec17c09c52a800e244961dba05251f5aaf923afabd9c9804d1a"
+```
+
 #### `class-hash`
 
 Get the class hash of a model

--- a/src/toolchain/sozo/world-commands/model.md
+++ b/src/toolchain/sozo/world-commands/model.md
@@ -10,19 +10,19 @@
 sozo model <COMMAND>
 
 Commands:
-  get     Get the class hash of a model
-  schema  Retrieve the schema for a model
-  entity  Get the model value for an entity
+  class-hash  Get the class hash of a model
+  schema      Retrieve the schema for a model
+  get         Get the model value for an entity
 ```
 
 ### SUBCOMMANDS
 
-#### `get`
+#### `class-hash`
 
 Get the class hash of a model
 
 ```sh
-sozo model get <NAME>
+sozo model class-hash <NAME>
 ```
 
 ##### Arguments
@@ -43,12 +43,12 @@ sozo model schema <NAME>
 _`NAME`_  
 &nbsp;&nbsp;&nbsp;&nbsp;The name of the model
 
-#### `entity`
+#### `get`
 
 Get the model value for an entity
 
 ```sh
-sozo model entity <NAME> [KEYS]...
+sozo model get <NAME> [KEYS]...
 ```
 
 ##### Arguments


### PR DESCRIPTION
Update `sozo model `commands as they are outdated. The commands now look like this:
- `class-hash`: Get the class hash of a model
- `schema`: Retrieve the schema for a model
- `get`: Get the model value for an entity.

[Source code](https://github.com/dojoengine/dojo/blob/3bb35a6790de3eea83e5c728ed0de46523a3de10/crates/sozo/src/commands/model.rs#L18)