### PR TITLE
Add information about sozo arguments priorities #176

### DIFF
--- a/docs/pages/toolchain/sozo/common-options/configurations.md
+++ b/docs/pages/toolchain/sozo/common-options/configurations.md
@@ -11,14 +11,9 @@ The configuration system follows the following priority order:
 
 ## Account Options
 
-- `account_address`: Starknet account address. Can be specified via command-line arguments or environment variables.
+- `account_address`: Starknet account address.
 - `signer`: Options related to signer configuration.
 - `legacy`: Enables the use of a legacy account (cairo0 account).
-
-## Public Methods
-
-- `account(provider, env_metadata)`: Creates a Starknet account using the specified options. Takes into account the configuration priorities to determine the account address and other settings.
-- `account_address(env_metadata)`: Returns the Starknet account address. Takes into account the configuration priorities.
 
 ## Usage Examples
 

--- a/docs/pages/toolchain/sozo/common-options/configurations.md
+++ b/docs/pages/toolchain/sozo/common-options/configurations.md
@@ -35,3 +35,9 @@ The configuration system follows the following priority order:
    ```bash
    sozo --rpc-url http://localhost:7474/
    ```
+
+### Use a keystore file for account configuration
+
+   ```bash
+   sozo --keystore-path /path/to/keystore.json --keystore-password mypassword
+   ```

--- a/docs/pages/toolchain/sozo/common-options/configurations.md
+++ b/docs/pages/toolchain/sozo/common-options/configurations.md
@@ -39,5 +39,5 @@ The configuration system follows the following priority order:
 ### Use a keystore file for account configuration
 
    ```bash
-   sozo --keystore-path /path/to/keystore.json --keystore-password mypassword
+   sozo  <some subcommand> --keystore /path/to/keystore.json --password mypassword
    ```

--- a/docs/pages/toolchain/sozo/common-options/configurations.md
+++ b/docs/pages/toolchain/sozo/common-options/configurations.md
@@ -1,0 +1,47 @@
+# Account Options
+
+This module provides options for configuring an account in the `sozo` command.
+
+## Configuration Priorities
+
+The configuration system follows the following priority order:
+
+1. Command-line arguments: If options are specified via command-line arguments, they have the highest priority.
+2. Environment variables: Environment variables provide a way to configure options globally.
+3. Configuration in `Scarb.toml`: Any configuration found within the `Scarb.toml` file will be considered if options are not found in the first two steps.
+
+## Account Options
+
+- `account_address`: StarkNet account address. Can be specified via command-line arguments or environment variables.
+- `signer`: Options related to signer configuration.
+- `legacy`: Enables the use of a legacy account (cairo0 account).
+
+## Public Methods
+
+- `account(provider, env_metadata)`: Creates a StarkNet account using the specified options. Takes into account the configuration priorities to determine the account address and other settings.
+- `account_address(env_metadata)`: Returns the StarkNet account address. Takes into account the configuration priorities.
+
+## Usage Examples
+
+1. Specify the StarkNet account address and Starknet RPC URL using command-line arguments:
+
+   ```bash
+   sozo --account-address 0x123456789 --rpc-url http://localhost:7474/
+
+
+## Starknet Options
+
+- `rpc_url`: The URL of the Starknet RPC endpoint. Can be specified via command-line arguments or environment variables.
+
+## Public Methods
+
+- `provider(env_metadata)`: Creates a JSON-RPC client for interacting with the Starknet RPC endpoint. Takes into account the configuration priorities to determine the RPC URL.
+- `url(env_metadata)`: Retrieves the RPC URL configured for Starknet options. Takes into account the configuration priorities.
+
+## Usage Examples
+
+1. Specify the Starknet RPC URL using a command-line argument:
+
+   ```bash
+   sozo --rpc-url http://localhost:7474/
+

--- a/docs/pages/toolchain/sozo/common-options/configurations.md
+++ b/docs/pages/toolchain/sozo/common-options/configurations.md
@@ -1,8 +1,4 @@
-# Account Options
-
-This module provides options for configuring an account in the `sozo` command.
-
-## Configuration Priorities
+# Configuration Priorities
 
 The configuration system follows the following priority order:
 1. Command-line arguments
@@ -15,29 +11,24 @@ The configuration system follows the following priority order:
 - `signer`: Options related to signer configuration.
 - `legacy`: Enables the use of a legacy account (cairo0 account).
 
-## Usage Examples
+### Usage Examples
 
-1. Specify the Starknet account address and Starknet RPC URL using command-line arguments:
+1. Specify the Starknet account address using command-line arguments:
 
-   ```bash
-   sozo --account-address 0x123456789 --rpc-url http://localhost:7474/
-   ```
-
+```bash
+sozo --account-address 0x123456789
+```
 
 ## Starknet Options
 
 - `rpc_url`: The URL of the Starknet RPC endpoint. Can be specified via command-line arguments or environment variables.
 
-## Usage Examples
+### Usage Examples
 
 1. Specify the Starknet RPC URL using a command-line argument:
 
-   ```bash
-   sozo --rpc-url http://localhost:7474/
-   ```
+```bash
+sozo --rpc-url http://localhost:7474/
+```
 
-### Use a keystore file for account configuration
-
-   ```bash
-   sozo  <some subcommand> --keystore /path/to/keystore.json --password mypassword
-   ```
+TODO: Add documentation of other common options

--- a/docs/pages/toolchain/sozo/common-options/configurations.md
+++ b/docs/pages/toolchain/sozo/common-options/configurations.md
@@ -5,38 +5,33 @@ This module provides options for configuring an account in the `sozo` command.
 ## Configuration Priorities
 
 The configuration system follows the following priority order:
-
-1. Command-line arguments: If options are specified via command-line arguments, they have the highest priority.
-2. Environment variables: Environment variables provide a way to configure options globally.
-3. Configuration in `Scarb.toml`: Any configuration found within the `Scarb.toml` file will be considered if options are not found in the first two steps.
+1. Command-line arguments
+2. Environment variables
+3. Configuration in `Scarb.toml`
 
 ## Account Options
 
-- `account_address`: StarkNet account address. Can be specified via command-line arguments or environment variables.
+- `account_address`: Starknet account address. Can be specified via command-line arguments or environment variables.
 - `signer`: Options related to signer configuration.
 - `legacy`: Enables the use of a legacy account (cairo0 account).
 
 ## Public Methods
 
-- `account(provider, env_metadata)`: Creates a StarkNet account using the specified options. Takes into account the configuration priorities to determine the account address and other settings.
-- `account_address(env_metadata)`: Returns the StarkNet account address. Takes into account the configuration priorities.
+- `account(provider, env_metadata)`: Creates a Starknet account using the specified options. Takes into account the configuration priorities to determine the account address and other settings.
+- `account_address(env_metadata)`: Returns the Starknet account address. Takes into account the configuration priorities.
 
 ## Usage Examples
 
-1. Specify the StarkNet account address and Starknet RPC URL using command-line arguments:
+1. Specify the Starknet account address and Starknet RPC URL using command-line arguments:
 
    ```bash
    sozo --account-address 0x123456789 --rpc-url http://localhost:7474/
+   ```
 
 
 ## Starknet Options
 
 - `rpc_url`: The URL of the Starknet RPC endpoint. Can be specified via command-line arguments or environment variables.
-
-## Public Methods
-
-- `provider(env_metadata)`: Creates a JSON-RPC client for interacting with the Starknet RPC endpoint. Takes into account the configuration priorities to determine the RPC URL.
-- `url(env_metadata)`: Retrieves the RPC URL configured for Starknet options. Takes into account the configuration priorities.
 
 ## Usage Examples
 
@@ -44,4 +39,4 @@ The configuration system follows the following priority order:
 
    ```bash
    sozo --rpc-url http://localhost:7474/
-
+   ```

--- a/vocs.config.ts
+++ b/vocs.config.ts
@@ -248,6 +248,10 @@ export default defineConfig({
                   text: "auth",
                   link: "/toolchain/sozo/world-commands/auth",
                 },
+                {
+                  text: "configruations",
+                  link: "/toolchain/sozo/common-options/configurations",
+                },
               ],
             },
           ],


### PR DESCRIPTION
This the issue https://github.com/dojoengine/book/issues/176

Sozo is being reworked to have these priorities:

- CLI arguments always takes precedence.
- Then the environment variables.
- Finally, anything found inside the scarb manifest.

We may add a section on that on the book once this PR is merged https://github.com/dojoengine/dojo/pull/1405 to bring better understanding for the user to the possibilities around configurations.

![Captura de pantalla 2024-05-12 a la(s) 6 47 55 p  m](https://github.com/dojoengine/book/assets/55175623/40dc577a-a454-4fc7-bad0-4c8d0b8ed674)
