### PR TITLE
Solution of the issue 2047

### DIFF
--- a/docs/pages/toolchain/sozo/project-commands/build.md
+++ b/docs/pages/toolchain/sozo/project-commands/build.md
@@ -21,7 +21,7 @@ For example, to generate the unity bindings, you can do:
 sozo build --unity
 ```
 
-If you encounter the error message `<error: could not execute process>`, this indicates that Cargo experienced an issue while attempting to retrieve the project's dependencies. Use the command, as this  resolve the problem.
+If you encounter the error message `<error: could not execute process>`, this indicates that Cargo experienced an issue while attempting to retrieve the project dependencies. Use the command, as this  resolve the problem.
 
 ```sh
 cargo fetch

--- a/docs/pages/toolchain/sozo/project-commands/build.md
+++ b/docs/pages/toolchain/sozo/project-commands/build.md
@@ -20,3 +20,9 @@ For example, to generate the unity bindings, you can do:
 ```sh
 sozo build --unity
 ```
+
+If you encounter the error message `<error: could not execute process>`, this indicates that Cargo experienced an issue while attempting to retrieve the project's dependencies. Use the command, as this  resolve the problem.
+
+```sh
+cargo fetch
+```


### PR DESCRIPTION
Issue -> [https://github.com/dojoengine/dojo/issues/2047](url)

I conducted tests on the reported issue. When starting a project from scratch and configuring the prerequisites, attempting to build the project with `sozo build` resulted in the error `error: could not execute process`, as mentioned in the corresponding issue. Documentation on how to proceed if this error occurs has been added to the `sozo build` section.

![image](https://github.com/dojoengine/book/assets/91926755/305adcec-85e1-4114-87c7-82b6371af9ec)
