### PR TITLE
doc: sozo init doc

### DIFF
--- a/docs/pages/toolchain/sozo/project-commands/init.md
+++ b/docs/pages/toolchain/sozo/project-commands/init.md
@@ -5,3 +5,9 @@
 ```sh
 sozo init new_project
 ```
+
+To initialize a new project with git, pass in the `--git` flag.
+
+```sh
+sozo init new_project --git
+```


### PR DESCRIPTION
This PR updates the documentation on initializing a new dojo project using `sozo init`.