### PR TITLE
update /docs/pages/quickstarts /react.mdx

### DIFF
--- a/docs/pages/quickstarts/react.mdx
+++ b/docs/pages/quickstarts/react.mdx
@@ -68,6 +68,18 @@ torii --http.cors_origins "*" --world 0x00e2ea9b5dd9804d13903edf712998943b7d5d60
 
 5. Setup client
 
+# Update dojoConfig.ts
+```bash
+import { createDojoConfig } from "@dojoengine/core";
+
+import manifest from "../contract/manifest_dev.json";
+
+export const dojoConfig = createDojoConfig({
+    manifest,
+});
+dojoConfig.toriiUrl="http://localhost:8080"
+```
+
 ```bash
 cd client
 pnpm i

--- a/docs/pages/quickstarts/react.mdx
+++ b/docs/pages/quickstarts/react.mdx
@@ -69,7 +69,7 @@ torii --http.cors_origins "*" --world 0x00e2ea9b5dd9804d13903edf712998943b7d5d60
 5. Setup client
 
 ```bash
-# Update dojoConfig.ts, replaced by following code.
+# Update client/dojoConfig.ts, replaced by following code.
 
 import { createDojoConfig } from "@dojoengine/core";
 

--- a/docs/pages/quickstarts/react.mdx
+++ b/docs/pages/quickstarts/react.mdx
@@ -68,8 +68,9 @@ torii --http.cors_origins "*" --world 0x00e2ea9b5dd9804d13903edf712998943b7d5d60
 
 5. Setup client
 
-# Update dojoConfig.ts
 ```bash
+# Update dojoConfig.ts, replaced by following code.
+
 import { createDojoConfig } from "@dojoengine/core";
 
 import manifest from "../contract/manifest_dev.json";


### PR DESCRIPTION
The current version can't run correctly since it showed the error message "ERR_ADDRESS_INVALID".

we need to add one line at the end of sojoConfig.ts in order to let the project run correctly.
```
dojoConfig.toriiUrl="http://localhost:8080"
```

Actually, the beginner may not know how to solve it. Therefore, we need to remind the beginner to update the dojoConfig.ts. In the case, we can let beginner know more about the config seeting.