### PR TITLE
Improve Models Documentation: Explain why Drop and Serde Traits are mandatory

### DIFF
--- a/docs/pages/framework/models/index.md
+++ b/docs/pages/framework/models/index.md
@@ -33,7 +33,7 @@ struct Moves {
 ```
 
 :::tip
-The `#[derive(Drop, Serde)]` are required and must be included to avoid compilation error. You can add additional trait as you may require, for example the `Copy` trait.
+The `#[derive(Drop, Serde)]` traits are required, respectively used by [cairo ownership system](https://book.cairo-lang.org/ch04-01-what-is-ownership.html) then for [serializing](https://book.cairo-lang.org/appendix-03-derivable-traits.html?#serializing-with-serde) model. Missing them will automatically lead to a compilation error. You can add additional traits as needed, for example, the `Copy` trait.
 :::
 
 ## The #[key] attribute


### PR DESCRIPTION
## Description
This PR enhances the documentation by adding a clear explanation of why the Drop and Serde traits are mandatory.

## Motivation
This update encourages continuous learning for developers who are not yet fully familiar with Cairo, helping them better understand key concepts and lowering the entry barrier.

## Request for Reviewers
Feedback on the clarity and accuracy of the explanation is welcome.

Let me know if further adjustments are needed!