### PR TITLE
Sozo: add calldata format page + external contracts configuration description

### DIFF
--- a/docs/pages/framework/config.md
+++ b/docs/pages/framework/config.md
@@ -131,6 +131,29 @@ private_key = "0xc5b2fcab997346f3ea1c00b002ecf6f382c5f9c9659a3894eb783c5320f912"
 default = "ns"
 mappings = { "ns" = ["c1", "M"], "ns2" = ["c1", "M"] }
 
+[[models]]
+tag = "ns-Position"
+description = "position of a player in the world"
+
+[[events]]
+tag = "ns-Moved"
+description = "when a player has moved"
+
+[[contracts]]
+tag = "ns-actions"
+description = "set of actions for a player"
+
+[[external_contracts]]
+contract_name = "ERC20Token"
+instance_name = "GoldToken"
+salt = "1"
+constructor_data = ["str:Gold", "str:GOLD", "u256:0x10000000000000", "0x2af9427c5a277474c079a1283c880ee8a6f0f8fbf73ce969c08d88befec1bba"]
+
+[[external_contracts]]
+contract_name = "Saloon"
+constructor_data = []
+salt = "1"
+
 [init_call_args]
 "ns-c1" = ["0xfffe"]
 "ns2-c1" = ["0xfffe"]
@@ -199,6 +222,8 @@ To initialize this contract, you need to add the following to your `dojo_<PROFIL
 
 Remember that a resource is always namespaced. So you need to specify the `tag` (which is `<NAMESPACE>-<CONTRACT_NAME>`) in the `init_call_args` section to identify it.
 
+Must use the Dojo calldata format described [here](/toolchain/sozo/calldata_format).
+
 ### `[writers]`/`[owners]`
 
 The writers/owners configuration allows you to specify permissions directly from the configuration file for the given profile.
@@ -230,4 +255,18 @@ The supported keys are:
 
 ### `[world]`
 
-The metadata related to your world. They are purely informative.
+The metadata related to your world. They are purely informative. More details [here](/framework/world/metadata/#world-metadata).
+
+### `[[models]]`, `[[events]]` and `[[contracts]]`
+
+The metadata related to your world resources. They are purely informative. More details [here](/framework/world/metadata/#resource-metadata).
+
+### `[[external_contracts]]`
+
+To be managed by `sozo`, external Cairo contracts (i.e non Dojo contracts) must be declared in your `dojo_<profile>.toml` file. For each contract instance a `[[external_contracts]]` block must be added with:
+- `contract_name`: the name of the Cairo contract to deploy,
+- `instance_name`: if you want to deploy several instances of a same Cairo contract (for example, `ERC20`), you have to give a specific name to each instance. If you have only one instance, don't provide any value for `instance_name`, it will automatically be set to the `contract_name` value,
+- `salt`: salt value to use to compute the contract address (hashed with the `instance_name` to get the final salt used for contract deployment),
+- `constructor_data`: a list of calldata to give to the Cairo contract constructor. If the constructor does not have any parameter, just omit this parameter. Must use the Dojo calldata format described [here](/toolchain/sozo/calldata_format). 
+
+Then, during the migration, sozo will declare and deploy these external contracts and update the manifest output file.

--- a/docs/pages/toolchain/sozo/calldata_format.md
+++ b/docs/pages/toolchain/sozo/calldata_format.md
@@ -1,0 +1,18 @@
+# Calldata format
+
+In the Dojo ecosystem, several tools or configuration files like `sozo` and the `dojo_<PROFILE>.toml` file require some calldata to be provided. This page describes the format which is expected for these calldata.
+
+By default, any calldata value is a Cairo felt or any type that fits into one felt.
+
+To be decoded as other Cairo types, calldata values must be prefixed. Here is a list of available prefixes:
+
+| Prefix          | Description      | Example |
+| --------------- | ---------------- | ------- |
+| `u256`          | a 256-bit unsigned integer | `u256:0x1234` |
+| `str`           | a Cairo string (ByteArray) | `str:'hello world'` |
+| `sstr`          | a Cairo short string       | `sstr:'hello world'` |
+| `int`           | a signed integer that fits into a `i128` | `int:0x1234` |
+| `arr`           | a dynamic array of values that fits into one felt | `arr:0x01,0x02,0x03` | 
+| `u256arr`       | a dynamic array of 256-bit unsigned integers | `u256arr:0x01,0x02,0x03` |
+| `farr`          | a fixed-size array of values that fits into one felt | `farr:0x01,0x02,0x03` |
+| `u256farr`      | a fixed-size array of 256-bit unsigned integers | `u256farr:0x01,0x02,0x03` |

--- a/docs/pages/toolchain/sozo/world-commands/call.mdx
+++ b/docs/pages/toolchain/sozo/world-commands/call.mdx
@@ -29,8 +29,10 @@ _`ENTRYPOINT`_
 #### General Options
 
 `--calldata [-c]` _CALLDATA_  
-&nbsp;&nbsp;&nbsp;&nbsp;The calldata to be passed to the system that you want to execute.  
+&nbsp;&nbsp;&nbsp;&nbsp;The calldata to be passed to the system that you want to execute.
 &nbsp;&nbsp;&nbsp;&nbsp;Comma separated values e.g., 0x12345,0x69420.
+
+Must use the Dojo calldata format described [here](/toolchain/sozo/calldata_format).
 
 `--block-id [-b]` _BLOCK_ID_  
 &nbsp;&nbsp;&nbsp;&nbsp;The block ID (could be a hash, a number, 'pending' or 'latest') to do the call on.

--- a/docs/pages/toolchain/sozo/world-commands/execute.mdx
+++ b/docs/pages/toolchain/sozo/world-commands/execute.mdx
@@ -33,13 +33,7 @@ _`ENTRYPOINT`_
 _`CALLDATA`_
 &nbsp;&nbsp;&nbsp;&nbsp; _(optional)_ The calldata to be passed to the system that you want to execute. Comma separated values e.g., 0x12345,0x69420.
 
-Sozo supports some prefixes that you can use to automatically parse some types.\
-The supported prefixes are:
-- `u256`: A 256-bit unsigned integer.
-- `sstr`: A cairo short string.
-- `str`: A cairo string (ByteArray).
-- `int`: A signed integer.
-- no prefix: A cairo felt or any type that fit into one felt.
+Must use the Dojo calldata format described [here](/toolchain/sozo/calldata_format).
 
 ### OPTIONS
 

--- a/routes.ts
+++ b/routes.ts
@@ -212,6 +212,10 @@ export const routes = [
                         link: "/toolchain/sozo",
                     },
                     {
+                        text: "Calldata format",
+                        link: "/toolchain/sozo/calldata_format",
+                    },
+                    {
                         text: "Reference",
                         collapsed: true,
                         items: [


### PR DESCRIPTION
This PR adds:
- a dedicated page to describe the calldata format used by `sozo` and some configuration files,
- a description of the new `external_contracts` block in `dojo_<PROFILE>.toml` and added in this PR https://github.com/dojoengine/dojo/pull/2995.

