### PR TITLE
docs: add Claude Code skills installation to getting started

### DIFF
--- a/docs/pages/getting-started/index.mdx
+++ b/docs/pages/getting-started/index.mdx
@@ -72,6 +72,18 @@ Before starting, ensure you have:
 
 > **Note**: No prior blockchain or Cairo experience is required. We'll explain concepts as we go.
 
+## Working with Claude Code
+
+Dojo provides official Claude skills that help you work through various parts of a Dojo project.
+When installed, Claude can pull up relevant context as needed to assist with models, systems, testing, deployment, and more.
+
+To install the skills, run the following commands inside your Claude session:
+
+```bash
+/plugin marketplace add dojoengine/marketplace
+/plugin install book@dojoengine
+```
+
 ## Getting Help
 
 If you get stuck during these tutorials:


### PR DESCRIPTION
## Summary

- Adds a "Working with Claude Code" section to the Getting Started page
- Documents how to install the official Dojo Claude skills

## Test plan

- [x] Build passes (`pnpm run build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)