### PR TITLE
docs: add npx skills alternative for Claude installation

### DIFF
--- a/docs/pages/getting-started/index.mdx
+++ b/docs/pages/getting-started/index.mdx
@@ -84,6 +84,12 @@ To install the skills, run the following commands inside your Claude session:
 /plugin install book@dojoengine
 ```
 
+Alternatively, you can install the skills using the `skills` npm package:
+
+```bash
+npx skills add dojoengine/book
+```
+
 ## Getting Help
 
 If you get stuck during these tutorials:


### PR DESCRIPTION
Add alternative installation method using the `skills` npm package for users who prefer npm tooling.
The npx approach downloads the repository with a shallow clone and only installs the skill files, then cleans up the temporary directory.
This complements the existing Claude marketplace installation method.

## Testing

- Verified build passes
- Confirmed skills directory structure is discoverable by the skills package