### PR TITLE
docs: move Claude Code skills to installation

### DIFF
--- a/docs/pages/getting-started/index.mdx
+++ b/docs/pages/getting-started/index.mdx
@@ -72,24 +72,6 @@ Before starting, ensure you have:
 
 > **Note**: No prior blockchain or Cairo experience is required. We'll explain concepts as we go.
 
-## Working with Claude Code
-
-Dojo provides official Claude skills that help you work through various parts of a Dojo project.
-When installed, Claude can pull up relevant context as needed to assist with models, systems, testing, deployment, and more.
-
-To install the skills, run the following commands inside your Claude session:
-
-```bash
-/plugin marketplace add dojoengine/marketplace
-/plugin install book@dojoengine
-```
-
-Alternatively, you can install the skills using the `skills` npm package:
-
-```bash
-npx skills add dojoengine/book
-```
-
 ## Getting Help
 
 If you get stuck during these tutorials:

--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -338,6 +338,16 @@ Install the [Cairo 1.0](https://marketplace.visualstudio.com/items?itemName=star
 
 If you run into problems getting started with Dojo, join our [Discord](https://discord.gg/invite/dojoengine) and ask for help.
 
+## Claude Code Skills
+
+Dojo provides official [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) skills that give Claude relevant context for working with models, systems, testing, deployment, and more.
+
+To install the skills, run the following in your terminal:
+
+```bash
+npx skills add dojoengine/book
+```
+
 ## Next Steps
 
 With Dojo installed, you're ready to start building:


### PR DESCRIPTION
Move the Claude Code section from getting-started to installation, and simplify to only show the npx skills add flow.

This consolidates tool setup instructions in the installation guide.

🤖 Generated with Claude Code