### PR TITLE
docs: move Claude Code Skills section after Verification

### DIFF
--- a/docs/pages/installation.mdx
+++ b/docs/pages/installation.mdx
@@ -257,6 +257,16 @@ sozo build
 # Test successful if no errors appear
 ```
 
+## Claude Code Skills
+
+Dojo provides official [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) skills that give Claude relevant context for working with models, systems, testing, deployment, and more.
+
+To install the skills, run the following in your terminal:
+
+```bash
+npx skills add dojoengine/book
+```
+
 ## Troubleshooting
 
 ### Common Installation Issues
@@ -337,16 +347,6 @@ Install the [Cairo 1.0](https://marketplace.visualstudio.com/items?itemName=star
 ## Getting Help
 
 If you run into problems getting started with Dojo, join our [Discord](https://discord.gg/invite/dojoengine) and ask for help.
-
-## Claude Code Skills
-
-Dojo provides official [Claude Code](https://docs.anthropic.com/en/docs/claude-code/overview) skills that give Claude relevant context for working with models, systems, testing, deployment, and more.
-
-To install the skills, run the following in your terminal:
-
-```bash
-npx skills add dojoengine/book
-```
 
 ## Next Steps
 


### PR DESCRIPTION
## Summary

Moved the Claude Code Skills installation instructions to appear right after the Verification section.
This makes the optional enhancement tools more visible to users and creates a clearer flow from confirming the installation to discovering relevant AI-assisted development skills.

## Motivation

The Claude Code Skills section was previously at the bottom of the page after Getting Help, which made it easy to miss.
Placing it immediately after Verification helps users discover these tools at a natural point in the installation workflow.