### PR TITLE
Resolve four stale GitHub issues (#421, #407, #400, #346)

### DIFF
--- a/docs/pages/faq.md
+++ b/docs/pages/faq.md
@@ -68,3 +68,18 @@ If you have ideas for the project, please open an issue.
 ### How do I get involved?
 
 Check out our [Github](https://github.com/dojoengine/dojo/blob/main/CONTRIBUTING.md), [Twitter](https://x.com/ohayo_dojo), or [Discord](https://discord.gg/invite/dojoengine).
+
+## Known Limitations
+
+### Starknet contract size limit
+
+Starknet enforces a maximum size for contract classes.
+If your Dojo contract grows too large (many systems or complex logic in a single contract), deployment will fail with a size limit error.
+
+The mitigation is to split logic across multiple contracts or use [Dojo libraries](/framework/systems/libraries) to separate reusable logic from your contracts via library calls.
+
+### Models inside models
+
+A `#[dojo::model]` struct cannot be used as a field inside another model.
+Use a plain struct deriving `Introspect` instead.
+See [Model Composition](/framework/models#model-composition) for details.

--- a/docs/pages/framework/models/index.md
+++ b/docs/pages/framework/models/index.md
@@ -115,7 +115,30 @@ struct Potions {
 ```
 
 Human entities will have `Health`, `Position`, and `Potions` models, while Orcs will have only `Health` and `Position`.
-This let's us re-use models to create a variety of different entities.
+This lets us re-use models to create a variety of different entities.
+
+:::warning
+A `#[dojo::model]` struct cannot be used as a field inside another model.
+This is because the key retrieval system requires fields to be serializable in a way that nested models do not support.
+
+If you need a composite data type as a model field, define a plain struct and derive [`Introspect`](/framework/models/introspection) instead:
+
+```cairo
+#[derive(Drop, Serde, Introspect)]
+struct Stats {
+    atk: u8,
+    def: u8,
+}
+
+#[derive(Drop, Serde)]
+#[dojo::model]
+struct Player {
+    #[key]
+    id: u32,
+    stats: Stats, // Plain struct with Introspect, not a model
+}
+```
+:::
 
 The game contract would look like this:
 

--- a/docs/pages/framework/models/introspection.md
+++ b/docs/pages/framework/models/introspection.md
@@ -26,6 +26,8 @@ The `dojo/core` library already implements the `Introspect` trait for Cairo buil
 ## Custom Types
 
 User-defined types must implement the `Introspect` trait to be used inside of a model.
+Note that a `#[dojo::model]` struct cannot be embedded as a field in another model — use a plain struct with `Introspect` instead.
+See [Model Composition](/framework/models#model-composition) for details.
 
 ### Automatic Implementation
 

--- a/docs/pages/framework/systems/index.md
+++ b/docs/pages/framework/systems/index.md
@@ -167,8 +167,21 @@ mod game_actions {
 
 ### Initialization
 
-Systems don't require explicit initialization - they're stateless functions.
-However, systems may need to initialize world state on first use.
+Systems are stateless functions and don't have constructors.
+However, Dojo contracts support a `dojo_init` function that acts as a constructor-equivalent.
+The World calls `dojo_init` on each contract during `sozo migrate`, after the contract is registered.
+
+```cairo
+#[dojo::contract]
+mod my_system {
+    fn dojo_init(ref self: ContractState, arg1: felt252, arg2: u256) {
+        // Called once during migration - use for one-time setup
+    }
+}
+```
+
+Initialization arguments are configured in your profile's `[init_call_args]` section.
+See [Contract Initialization](/framework/configuration#contract-initialization) for details.
 
 ### Execution
 

--- a/docs/pages/tutorials/dojo-starter.mdx
+++ b/docs/pages/tutorials/dojo-starter.mdx
@@ -107,19 +107,10 @@ The `Position` model, like `Moves`, is indexed by the `player` field and include
 
 ## Contract Systems
 
-A dojo contract is just a regular Starknet contract which is defined with the `#[dojo::contract]` attribute.
+A dojo contract is a Starknet contract annotated with the `#[dojo::contract]` attribute.
+Like any Starknet contract, it defines an interface and an implementation.
 
-First, a dojo contract must define one (or more) Dojo interfaces.
-
-```rust
-#[starknet::interface]
-pub trait IActions<T> {
-    fn spawn(ref self: T);
-    fn move(ref self: T, direction: Direction);
-}
-```
-
-Now, let's examine a contract implementation of the `src/systems/actions.cairo` file.
+Let's examine the `src/systems/actions.cairo` file.
 
 ```rust
 use dojo_starter::models::{Direction, Position};

--- a/docs/styles.css
+++ b/docs/styles.css
@@ -43,10 +43,6 @@ h6 {
     padding-bottom: 0;
 }
 
-.vocs_DesktopTopNav_withLogo {
-    padding-left: 175px;
-}
-
 :not(.vocs_Header) + .vocs_H2:not(:only-child),
 .vocs_Sidebar_navigation
     > .vocs_Sidebar_group


### PR DESCRIPTION
## Summary

Resolved four long-standing GitHub issues in the documentation:

- Fixes #421: Fixed search bar blocked by CSS overlap (removed hardcoded padding-left override)
- Fixes #407: Removed outdated "Dojo interfaces" terminology and introduced dojo_init constructor pattern earlier in systems lifecycle
- Fixes #400: Added warning about nested models limitation with Introspect workaround
- Fixes #346: Documented Starknet contract size limit and related constraints in FAQ

All changes verified with `pnpm run build` passing without errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)