### PR TITLE
fix: reject LLM output that modifies links in defrag

### DIFF
--- a/scripts/defrag-sentence.mjs
+++ b/scripts/defrag-sentence.mjs
@@ -21,6 +21,7 @@ import {
     collectDocFiles,
     loadTextFile,
     callClaude,
+    checkLinksPreserved,
 } from "./lib/defrag-utils.mjs";
 
 const DRY_RUN = process.argv.includes("--dry-run");
@@ -104,6 +105,15 @@ async function main() {
             if (normalized === original) {
                 console.log(`    No changes.`);
                 filesUnchanged++;
+                continue;
+            }
+
+            const linkCheck = checkLinksPreserved(original, normalized);
+            if (!linkCheck.ok) {
+                console.warn(`    REJECTED: LLM modified links in ${file.rel}`);
+                if (linkCheck.added.length) console.warn(`      Added: ${linkCheck.added.join(", ")}`);
+                if (linkCheck.removed.length) console.warn(`      Removed: ${linkCheck.removed.join(", ")}`);
+                filesErrored++;
                 continue;
             }
 

--- a/scripts/defrag-terminology.mjs
+++ b/scripts/defrag-terminology.mjs
@@ -23,6 +23,7 @@ import {
     collectDocFiles,
     loadTextFile,
     callClaude,
+    checkLinksPreserved,
 } from "./lib/defrag-utils.mjs";
 import { join } from "path";
 
@@ -99,6 +100,15 @@ async function main() {
             if (normalized === original) {
                 console.log(`    No changes.`);
                 filesUnchanged++;
+                continue;
+            }
+
+            const linkCheck = checkLinksPreserved(original, normalized);
+            if (!linkCheck.ok) {
+                console.warn(`    REJECTED: LLM modified links in ${file.rel}`);
+                if (linkCheck.added.length) console.warn(`      Added: ${linkCheck.added.join(", ")}`);
+                if (linkCheck.removed.length) console.warn(`      Removed: ${linkCheck.removed.join(", ")}`);
+                filesErrored++;
                 continue;
             }
 

--- a/scripts/lib/defrag-utils.mjs
+++ b/scripts/lib/defrag-utils.mjs
@@ -52,6 +52,50 @@ export function getValidRoutes() {
 }
 
 /**
+ * Extract all markdown link URLs from content (ignoring code blocks).
+ */
+export function extractLinkUrls(content) {
+    const urls = [];
+    let inCodeBlock = false;
+    for (const line of content.split("\n")) {
+        if (line.trimStart().startsWith("```")) {
+            inCodeBlock = !inCodeBlock;
+            continue;
+        }
+        if (inCodeBlock) continue;
+        const linkRegex = /\[([^\]]*)\]\(([^)]+)\)/g;
+        let match;
+        while ((match = linkRegex.exec(line)) !== null) {
+            urls.push(match[2]);
+        }
+    }
+    return urls;
+}
+
+/**
+ * Check that the LLM output preserved all original links and added none.
+ * Returns { ok, added, removed } where added/removed are URL arrays.
+ */
+export function checkLinksPreserved(original, corrected) {
+    const originalUrls = extractLinkUrls(original);
+    const correctedUrls = extractLinkUrls(corrected);
+    const origCounts = new Map();
+    for (const u of originalUrls) origCounts.set(u, (origCounts.get(u) || 0) + 1);
+    const corrCounts = new Map();
+    for (const u of correctedUrls) corrCounts.set(u, (corrCounts.get(u) || 0) + 1);
+
+    const added = [];
+    const removed = [];
+    const allUrls = new Set([...origCounts.keys(), ...corrCounts.keys()]);
+    for (const u of allUrls) {
+        const diff = (corrCounts.get(u) || 0) - (origCounts.get(u) || 0);
+        if (diff > 0) for (let i = 0; i < diff; i++) added.push(u);
+        if (diff < 0) for (let i = 0; i < -diff; i++) removed.push(u);
+    }
+    return { ok: added.length === 0 && removed.length === 0, added, removed };
+}
+
+/**
  * Check if any single diff hunk exceeds the size limit.
  */
 export function checkHunkSizes(original, corrected, filename) {


### PR DESCRIPTION
## Summary

- Added `checkLinksPreserved()` to shared defrag utils — extracts all markdown link URLs from before/after content and rejects the LLM output if any links were added, removed, or changed
- Applied the guard to both `defrag-sentence.mjs` and `defrag-terminology.mjs`
- Rejected files are logged with details and counted as errors

Fixes the build failure in the latest defrag run where the sentence pass changed `/client/sdk/javascript` to the nonexistent `/client/sdk/typescript` in `dojo-react.mdx`, despite the prompt saying "Do NOT add or modify links." The LLM prompt is necessary but not sufficient — this adds a programmatic backstop.

## Test plan

- [ ] Run `node scripts/defrag-sentence.mjs --dry-run` and verify link-modifying outputs are rejected
- [ ] Run `node scripts/defrag-terminology.mjs --dry-run` and verify same
- [ ] Trigger a full defrag workflow run and confirm build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)