### PR TITLE
chore: remove ECS term casing from defrag and style guide

### DIFF
--- a/.github/workflows/defrag-docs.yaml
+++ b/.github/workflows/defrag-docs.yaml
@@ -87,7 +87,7 @@ jobs:
                     git add docs/
                     git commit -m "chore(defrag): phase 2b — terminology
 
-                  ECS term capitalization, proper nouns, hyphenation.
+                  Proper noun capitalization, hyphenation.
 
                   $(tail -10 terminology-output.txt)"
                   else
@@ -179,7 +179,7 @@ jobs:
                   </details>
 
                   ### Phase 2b: Terminology (LLM)
-                  ECS term capitalization, proper nouns, hyphenation. No other changes.
+                  Proper noun capitalization, hyphenation. No other changes.
 
                   <details><summary>Summary</summary>
 

--- a/scripts/defrag-terminology.mjs
+++ b/scripts/defrag-terminology.mjs
@@ -4,7 +4,6 @@
  * Pass B: Terminology normalization.
  *
  * LLM-powered but narrowly scoped:
- *   - ECS term capitalization (world/model/system/entity/event lowercase in prose)
  *   - Proper noun capitalization (Dojo, Cairo, Starknet, Katana, Torii, Sozo, Saya, Scarb)
  *   - Hyphenation fixes (on-chain → onchain, etc.)
  *
@@ -38,14 +37,9 @@ ${styleGuide}
 
 ## What you change
 
-1. **ECS terms in prose**: model, system, entity, event, world must be lowercase in running prose sentences. Keep them capitalized in:
-   - Headings (lines starting with #)
-   - Table column headers and table description cells
-   - Link text that is a proper name (e.g., "[World API](/framework/world/api)")
+1. **Proper noun capitalization**: Dojo, Cairo, Starknet (not StarkNet), Katana, Torii, Sozo, Saya, Scarb, Cartridge, MetaMask, React Native — capitalize in prose.
 
-2. **Proper noun capitalization**: Dojo, Cairo, Starknet (not StarkNet), Katana, Torii, Sozo, Saya, Scarb, Cartridge, MetaMask, React Native — capitalize in prose.
-
-3. **Hyphenation**: onchain (not on-chain), gasless (not gas-free/gas-less), multicall (not multi-call), cross-chain (keep hyphen).
+2. **Hyphenation**: onchain (not on-chain), gasless (not gas-free/gas-less), multicall (not multi-call), cross-chain (keep hyphen).
 
 ## What you must NOT do
 
@@ -53,7 +47,7 @@ ${styleGuide}
 - Do NOT split or join lines (no one-sentence-per-line changes).
 - Do NOT expand contractions.
 - Do NOT add or remove any content, paragraphs, sections, or sentences.
-- Do NOT rename headings (only fix capitalization of ECS terms in headings per the rules above).
+- Do NOT rename headings.
 - Do NOT add or modify links or cross-references.
 - Do NOT change code blocks, inline code, frontmatter, URLs, or any non-prose content.
 - Do NOT fix typos, grammar, or punctuation.

--- a/spec/style-guide-agents.md
+++ b/spec/style-guide-agents.md
@@ -16,9 +16,6 @@ For the full guide, see style-guide.md.
 - **Dojo**, **Cairo**, **Starknet**, **Katana**, **Torii**, **Sozo**, **Saya**, **Scarb**
 - Lowercase is fine in CLI commands and config keys.
 
-**ECS terms — capitalize when referring to Dojo concepts:**
-- **World** (root contract), **Model** (not "Component"), **System**, **Entity**, **Event**
-
 **Third-party — official branding:**
 - **Cartridge Controller** (first mention) → **Controller** (subsequent)
 - **MetaMask**, **React Native**

--- a/spec/style-guide.md
+++ b/spec/style-guide.md
@@ -54,20 +54,6 @@ These are proper nouns — always capitalize in prose:
 | **Saya** | "saya" in prose |
 | **Scarb** | "scarb" in prose (lowercase is fine in CLI commands) |
 
-### ECS terms
-
-Use **lowercase** for ECS terms in running prose (e.g., "define a model", "the world contract", "write a system").
-Capitalize in headings, link text, table headers, and table description cells (e.g., "Free World metadata", "Model Binding Errors").
-
-| Term | Notes |
-|------|-------|
-| **model** | Data structures decorated with `#[dojo::model]` |
-| **system** | Functions that modify models, implementing game logic |
-| **entity** | An addressable unit of state composed of models |
-| **event** | On-chain events decorated with `#[dojo::event]` |
-| **world** | The root contract that manages all state (capitalize in "World contract" as a proper noun) |
-| **component** | Avoid — use **model** instead (legacy term) |
-
 ### Third-party names
 
 Use official branding:


### PR DESCRIPTION
## Summary

Removes ECS term casing rules (model/system/entity/event/world) from the defrag pipeline and style guides. Claude does not apply these consistently, and the value is low.

- Dropped the ECS terms section from `spec/style-guide.md` and `spec/style-guide-agents.md`
- Removed ECS casing instructions from the `defrag-terminology.mjs` LLM prompt
- Updated workflow commit messages and PR body to no longer reference ECS casing