### PR TITLE
refactor: drop contraction rule and protect code regions in defrag

### DIFF
--- a/scripts/defrag-sentence.mjs
+++ b/scripts/defrag-sentence.mjs
@@ -5,7 +5,6 @@
  *
  * LLM-powered but narrowly scoped:
  *   - One sentence per line (break multi-sentence lines)
- *   - Contraction expansion (don't → do not, you're → you are, etc.)
  *
  * Nothing else — no rewording, no content changes, no terminology fixes,
  * no cross-references, no heading changes, no link modifications.
@@ -22,13 +21,14 @@ import {
     loadTextFile,
     callClaude,
     checkLinksPreserved,
+    checkCodeRegionsPreserved,
 } from "./lib/defrag-utils.mjs";
 
 const DRY_RUN = process.argv.includes("--dry-run");
 
-const SYSTEM_PROMPT = `You are a documentation formatting tool. You make exactly two types of changes and nothing else.
+const SYSTEM_PROMPT = `You are a documentation formatting tool. You make exactly one type of change and nothing else.
 
-## Task 1: One sentence per line
+## Task: One sentence per line
 
 Break multi-sentence prose lines so each sentence starts on its own line.
 
@@ -39,34 +39,15 @@ Rules:
 - Do NOT split on periods inside inline code backticks.
 - Do NOT reword, rephrase, or change any content.
 
-## Task 2: Contraction expansion
-
-Expand English contractions in prose text to their full forms.
-
-Common contractions to expand:
-- don't → do not, doesn't → does not, won't → will not, can't → cannot
-- shouldn't → should not, wouldn't → would not, couldn't → could not
-- isn't → is not, aren't → are not, wasn't → was not, weren't → were not
-- haven't → have not, hasn't → has not, hadn't → had not
-- you're → you are, they're → they are, we're → we are, it's → it is
-- let's → let us, here's → here is, there's → there is, that's → that is
-- what's → what is, who's → who is
-- you'll → you will, you've → you have, we've → we have
-- I'm → I am (rare in docs, but expand if found)
-
-Rules:
-- Do NOT expand contractions inside code blocks, inline code backticks, frontmatter, or URLs.
-- Do NOT expand contractions in quoted speech or proper names.
-- Preserve the original capitalization of the first letter (e.g., "Don't" → "Do not").
-
 ## What you must NOT do
 
 - Do NOT change any wording, phrasing, or meaning.
+- Do NOT expand or introduce contractions — leave them exactly as written.
 - Do NOT add or remove any content, paragraphs, or sentences.
-- Do NOT change terminology, capitalization (beyond contraction expansion), or heading text.
+- Do NOT change terminology, capitalization, or heading text.
 - Do NOT add or modify links or cross-references.
 - Do NOT change code blocks, frontmatter, or any non-prose content.
-- Do NOT fix typos, grammar, or punctuation (other than sentence splitting and contraction expansion).
+- Do NOT fix typos, grammar, or punctuation (other than sentence splitting).
 
 Return ONLY the complete corrected file content — no commentary, no wrapping, no code fences.
 If the file needs no changes, return it exactly as-is.`;
@@ -113,6 +94,14 @@ async function main() {
                 console.warn(`    REJECTED: LLM modified links in ${file.rel}`);
                 if (linkCheck.added.length) console.warn(`      Added: ${linkCheck.added.join(", ")}`);
                 if (linkCheck.removed.length) console.warn(`      Removed: ${linkCheck.removed.join(", ")}`);
+                filesErrored++;
+                continue;
+            }
+
+            const codeCheck = checkCodeRegionsPreserved(original, normalized);
+            if (!codeCheck.ok) {
+                console.warn(`    REJECTED: LLM modified code regions in ${file.rel}`);
+                for (const m of codeCheck.mismatches) console.warn(`      ${m}`);
                 filesErrored++;
                 continue;
             }

--- a/scripts/defrag-terminology.mjs
+++ b/scripts/defrag-terminology.mjs
@@ -23,6 +23,7 @@ import {
     loadTextFile,
     callClaude,
     checkLinksPreserved,
+    checkCodeRegionsPreserved,
 } from "./lib/defrag-utils.mjs";
 import { join } from "path";
 
@@ -37,21 +38,38 @@ ${styleGuide}
 
 ## What you change
 
-1. **Proper noun capitalization**: Dojo, Cairo, Starknet (not StarkNet), Katana, Torii, Sozo, Saya, Scarb, Cartridge, MetaMask, React Native — capitalize in prose.
+Apply these rules ONLY to prose text — never to code.
+
+1. **Proper noun capitalization**: Dojo, Cairo, Starknet (not StarkNet), Katana, Torii, Sozo, Saya, Scarb, Cartridge, MetaMask, React Native — capitalize when they appear in running prose.
 
 2. **Hyphenation**: onchain (not on-chain), gasless (not gas-free/gas-less), multicall (not multi-call), cross-chain (keep hyphen).
+
+## Protected regions — never modify
+
+These regions must be returned byte-for-byte identical to the input:
+
+- **Fenced code blocks** (anything between \`\`\` fences), including comments and string literals inside them.
+- **Inline code spans** (text inside single backticks: \`katana\`, \`sozo\`, \`Sozo\`). If a CLI tool name appears in backticks, do NOT change its capitalization — backticks signal this is a code token, not prose.
+- **URLs** in any context: full URLs in prose, inside quotes, inside code blocks, inside link targets. Do not change capitalization of host names or paths.
+- **Link text and link targets** in markdown links \`[text](target)\`.
+- **Frontmatter** (the YAML block at the top of the file between \`---\` markers).
+- **HTML/JSX attribute values and tag names.**
+
+Concrete examples of changes you must NOT make:
+- \`\`katana\`\` → \`\`Katana\`\` (inline code, leave alone)
+- \`https://api.cartridge.gg\` → \`https://api.Cartridge.gg\` (URL host, leave alone)
+- \`rpc_url = "https://api.cartridge.gg/..."\` inside a code block (never touch code blocks)
+- \`dojo.js\` → \`Dojo.js\` (package/module identifier, leave alone)
 
 ## What you must NOT do
 
 - Do NOT change any wording, phrasing, meaning, or sentence structure.
 - Do NOT split or join lines (no one-sentence-per-line changes).
-- Do NOT expand contractions.
+- Do NOT expand or introduce contractions.
 - Do NOT add or remove any content, paragraphs, sections, or sentences.
 - Do NOT rename headings.
 - Do NOT add or modify links or cross-references.
-- Do NOT change code blocks, inline code, frontmatter, URLs, or any non-prose content.
 - Do NOT fix typos, grammar, or punctuation.
-- Do NOT change link text or link targets.
 
 Return ONLY the complete corrected file content — no commentary, no wrapping, no code fences.
 If the file needs no changes, return it exactly as-is.`;
@@ -102,6 +120,14 @@ async function main() {
                 console.warn(`    REJECTED: LLM modified links in ${file.rel}`);
                 if (linkCheck.added.length) console.warn(`      Added: ${linkCheck.added.join(", ")}`);
                 if (linkCheck.removed.length) console.warn(`      Removed: ${linkCheck.removed.join(", ")}`);
+                filesErrored++;
+                continue;
+            }
+
+            const codeCheck = checkCodeRegionsPreserved(original, normalized);
+            if (!codeCheck.ok) {
+                console.warn(`    REJECTED: LLM modified code regions in ${file.rel}`);
+                for (const m of codeCheck.mismatches) console.warn(`      ${m}`);
                 filesErrored++;
                 continue;
             }

--- a/scripts/lib/defrag-utils.mjs
+++ b/scripts/lib/defrag-utils.mjs
@@ -96,6 +96,81 @@ export function checkLinksPreserved(original, corrected) {
 }
 
 /**
+ * Extract all fenced code block bodies and inline code spans from content.
+ * Returns { blocks, spans } where each is an ordered list of strings.
+ */
+export function extractCodeRegions(content) {
+    const blocks = [];
+    const spans = [];
+
+    const lines = content.split("\n");
+    let inBlock = false;
+    let buffer = [];
+    const prose = [];
+
+    for (const line of lines) {
+        if (line.trimStart().startsWith("```")) {
+            if (inBlock) {
+                blocks.push(buffer.join("\n"));
+                buffer = [];
+                inBlock = false;
+            } else {
+                inBlock = true;
+            }
+            continue;
+        }
+        if (inBlock) {
+            buffer.push(line);
+        } else {
+            prose.push(line);
+        }
+    }
+
+    const proseText = prose.join("\n");
+    const inlineRegex = /`([^`\n]+)`/g;
+    let m;
+    while ((m = inlineRegex.exec(proseText)) !== null) {
+        spans.push(m[1]);
+    }
+
+    return { blocks, spans };
+}
+
+/**
+ * Verify that all fenced code blocks and inline code spans are preserved
+ * verbatim between original and corrected content.
+ */
+export function checkCodeRegionsPreserved(original, corrected) {
+    const a = extractCodeRegions(original);
+    const b = extractCodeRegions(corrected);
+    const mismatches = [];
+
+    if (a.blocks.length !== b.blocks.length) {
+        mismatches.push(`block count: ${a.blocks.length} → ${b.blocks.length}`);
+    } else {
+        for (let i = 0; i < a.blocks.length; i++) {
+            if (a.blocks[i] !== b.blocks[i]) {
+                mismatches.push(`fenced block #${i + 1} modified`);
+            }
+        }
+    }
+
+    const aSpans = [...a.spans].sort();
+    const bSpans = [...b.spans].sort();
+    if (aSpans.length !== bSpans.length) {
+        mismatches.push(`inline code count: ${aSpans.length} → ${bSpans.length}`);
+    } else {
+        for (let i = 0; i < aSpans.length; i++) {
+            if (aSpans[i] !== bSpans[i]) {
+                mismatches.push(`inline code "${aSpans[i]}" → "${bSpans[i]}"`);
+            }
+        }
+    }
+
+    return { ok: mismatches.length === 0, mismatches };
+}
+
+/**
  * Check if any single diff hunk exceeds the size limit.
  */
 export function checkHunkSizes(original, corrected, filename) {

--- a/spec/style-guide.md
+++ b/spec/style-guide.md
@@ -24,7 +24,6 @@ It is the source of truth for automated tooling (defragmentation, linting) and h
 - Write in **present tense**: "This deploys the contract", not "This will deploy the contract".
 - Use **second person** ("you") for instructions, **third person** for describing system behavior ("the World contract manages all state").
 - Use **imperative mood** for procedural steps: "Configure the world", not "You should configure the world".
-- **Do not use contractions**: "do not", not "don't"; "you will", not "you'll".
 - Use the **Oxford comma**: "models, systems, and events".
 - Prefer **"e.g."** over "for example" in parentheticals.
 - Use **bold** for feature names and key concepts in running text.


### PR DESCRIPTION
## Summary

Tightens the two LLM-driven defrag passes in response to issues observed in PR #492:

- Contraction expansion produced stilted prose (`let us explore`, `we will retry` in code comments) and churned every monthly defrag. Rule dropped from `spec/style-guide.md` and removed from the sentence pass.
- The terminology pass capitalized CLI tool names inside backticks (`` `katana` `` → `` `Katana` ``) and URL hosts inside fenced code blocks (`https://api.cartridge.gg` → `https://api.Cartridge.gg`), both of which the style guide already carved out.

## Changes

- `spec/style-guide.md` — remove "do not use contractions".
- `scripts/defrag-sentence.mjs` — strip Task 2 (contraction expansion); add explicit "do not expand or introduce contractions" rule.
- `scripts/defrag-terminology.mjs` — new "Protected regions" section in the prompt with concrete counterexamples from PR #492.
- `scripts/lib/defrag-utils.mjs` — add `checkCodeRegionsPreserved`: hard post-check that rejects any file where a fenced block or inline code span changed byte-for-byte. Wired into both LLM passes, same pattern as `checkLinksPreserved`.

The validator is deliberately per-pass and strict: prompt instructions have been ignored before, so a post-check is the reliable guard.

## Test plan

- [ ] `pnpm run build` passes
- [ ] After merge, re-trigger the defrag workflow via `workflow_dispatch` and confirm the resulting PR no longer expands contractions or capitalizes inside backticks/URLs