### PR TITLE
ci: give claude-code-action pnpm and gh tooling for build+PR

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -22,10 +22,22 @@ jobs:
               with:
                   fetch-depth: 0
 
+            - uses: pnpm/action-setup@v4
+
+            - uses: actions/setup-node@v4
+              with:
+                  node-version: "24"
+                  cache: "pnpm"
+
+            - run: pnpm install --frozen-lockfile
+
             - uses: anthropics/claude-code-action@v1
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
+                  show_full_output: true
+                  claude_args: |
+                      --allowedTools "Bash(pnpm:*),Bash(gh:*)"
                   prompt: |
                       You are acting on the Dojo documentation repo. The project-level CLAUDE.md and the files in `spec/` (style-guide.md, page-types.md, best-practices.md) are the source of truth for writing conventions — read them before drafting changes.
 


### PR DESCRIPTION
The @claude trigger on defrag-analysis issues (#498) completed but produced no branch or PR, and 16 tool calls were denied.
Root cause: claude-code-action v1 disallows arbitrary Bash by default, and the workflow also lacks Node/pnpm, so the `pnpm run build` the prompt already asks for could not run.
This PR sets up pnpm + Node 24 (matching `build.yaml`), grants `Bash(pnpm:*),Bash(gh:*)` via `claude_args`, and temporarily enables `show_full_output` to surface any remaining denials in the next run's logs.
Commits still flow through the built-in GitHub MCP file ops — no raw `git push` permission needed.
Verify by commenting `@claude` on #498 after merge and checking that a PR is drafted.