### PR TITLE
ci: expand claude-code-action allowlist and enable progress tracking

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -35,9 +35,10 @@ jobs:
               with:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
+                  track_progress: true
                   show_full_output: true
                   claude_args: |
-                      --allowedTools "Bash(pnpm:*),Bash(gh:*)"
+                      --allowedTools "Edit,Write,Read,Glob,Grep,LS,MultiEdit,Bash(git:*),Bash(pnpm:*),Bash(gh:*)"
                   prompt: |
                       You are acting on the Dojo documentation repo. The project-level CLAUDE.md and the files in `spec/` (style-guide.md, page-types.md, best-practices.md) are the source of truth for writing conventions — read them before drafting changes.
 


### PR DESCRIPTION
Follow-up to #500. The previous run on issue #498 still produced no branch or PR — logs (now visible thanks to `show_full_output: true`) show 6 denials: four `git checkout -b`/`git switch -c` attempts and two `Edit` calls on `docs/pages/framework/systems/index.md`.

Root causes:
- `--allowedTools` is treated as a strict allowlist in the Claude Code SDK, so setting it to only `Bash(pnpm:*),Bash(gh:*)` silently dropped `Edit`, `Write`, `Read`, etc. The docs' own example re-lists them, which I missed.
- Even with `use_commit_signing: false`, Claude uses raw `git checkout -b` to create the working branch (MCP file ops only handle commits, not branching), so `Bash(git:*)` is required.

Also enables `track_progress: true` so `@claude` mentions get the eyes reaction and a live sticky status comment — matching the UX in other repos.