### PR TITLE
ci: enable use_sticky_comment for claude-code-action

### DIFF
--- a/.github/workflows/claude.yaml
+++ b/.github/workflows/claude.yaml
@@ -36,6 +36,7 @@ jobs:
                   anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
                   github_token: ${{ secrets.GITHUB_TOKEN }}
                   track_progress: true
+                  use_sticky_comment: true
                   show_full_output: true
                   claude_args: |
                       --allowedTools "Edit,Write,Read,Glob,Grep,LS,MultiEdit,Bash(git:*),Bash(pnpm:*),Bash(gh:*)"


### PR DESCRIPTION
Follow-up to #501. Adds `use_sticky_comment: true` so Claude's responses to `@claude` mentions update a single comment in place rather than appending a new one each turn — cleaner thread on repeat interactions.